### PR TITLE
chore: update cargo-workspaces to v0.3.6

### DIFF
--- a/cargo-publish-snapshot/action.yml
+++ b/cargo-publish-snapshot/action.yml
@@ -40,7 +40,7 @@ runs:
       uses: baptiste0928/cargo-install@v2.1.0
       with:
         crate: cargo-workspaces
-        version: v0.3.1
+        version: v0.3.6
 
     - name: Set version to snapshot
       shell: bash


### PR DESCRIPTION
Older versions fail to compile on Rust 1.80.0.
